### PR TITLE
Apply chown to /run directory not recursively

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -27,7 +27,8 @@ add_user() {
   echo "Starting with UID : $USER_ID"
   groupadd -g $GROUP_ID $GROUP_NAME || true
   useradd -u $USER_ID -g $GROUP_ID $USER_NAME || true
-  chown -R $USER_ID:$GROUP_ID /openblocks /openblocks-stacks /etc/nginx /var /etc/redis /run /etc/supervisor
+  chown -R $USER_ID:$GROUP_ID /openblocks /openblocks-stacks /etc/nginx /var /etc/redis /etc/supervisor
+  chown $USER_ID:$GROUP_ID /run
 }
 
 init_mongodb


### PR DESCRIPTION
Related Issue: #38 

As stated in [this comment](https://github.com/openblocks-dev/openblocks/issues/38#issuecomment-1325083799), kubernetes utilizes the `/run/secrets` directory as read-only path, which conflicts with the `chown -R /run` in docker entrypoint.sh.

To resolve this issue, this PR changes the `chown -R /run` to `chown /run`. I've tested that image with the new `entrypoint.sh` worked well on local self-hosted environment (with very basic setup though...) and also on the kubernetes pod.

