### PR TITLE
feat(config): add max-in-memory-size to 20MB by default in config yaml

### DIFF
--- a/server/openblocks-server/src/main/resources/selfhost/ce/application-selfhost.yml
+++ b/server/openblocks-server/src/main/resources/selfhost/ce/application-selfhost.yml
@@ -15,3 +15,5 @@ spring:
       uri: ${MONGODB_URI:mongodb://localhost:27017/openblocks?socketTimeoutMS=5000}
   redis:
     url: ${REDIS_URL:redis://localhost:6379}
+  codec:
+    max-in-memory-size: 20MB


### PR DESCRIPTION
feat(config): add max-in-memory-size to 20MB by default in config yaml