### PR TITLE
frontend body size env var for nginx

### DIFF
--- a/deploy/docker/frontend/01-update-nginx-conf.sh
+++ b/deploy/docker/frontend/01-update-nginx-conf.sh
@@ -4,7 +4,10 @@ set -e
 
 sed -i "s@__OPENBLOCKS_API_SERVICE_URL__@${OPENBLOCKS_API_SERVICE_URL:=http://localhost:8080}@" /etc/nginx/nginx.conf
 sed -i "s@__OPENBLOCKS_NODE_SERVICE_URL__@${OPENBLOCKS_NODE_SERVICE_URL:=http://localhost:6060}@" /etc/nginx/nginx.conf
+sed -i "s@__OPENBLOCKS_FRONTEND_BODY_SIZE__@${OPENBLOCKS_FRONTEND_BODY_SIZE:=1M}@" /etc/nginx/nginx.conf
+
 
 echo "nginx config updated with:"
 echo "    Openblocks api service URL: ${OPENBLOCKS_API_SERVICE_URL}"
 echo "   Openblocks node service URL: ${OPENBLOCKS_NODE_SERVICE_URL}"
+echo " Openblocks Frontend Body Size: ${OPENBLOCKS_FRONTEND_BODY_SIZE}"

--- a/deploy/docker/frontend/01-update-nginx-conf.sh
+++ b/deploy/docker/frontend/01-update-nginx-conf.sh
@@ -5,9 +5,10 @@ set -e
 sed -i "s@__OPENBLOCKS_API_SERVICE_URL__@${OPENBLOCKS_API_SERVICE_URL:=http://localhost:8080}@" /etc/nginx/nginx.conf
 sed -i "s@__OPENBLOCKS_NODE_SERVICE_URL__@${OPENBLOCKS_NODE_SERVICE_URL:=http://localhost:6060}@" /etc/nginx/nginx.conf
 sed -i "s@__OPENBLOCKS_FRONTEND_BODY_SIZE__@${OPENBLOCKS_FRONTEND_BODY_SIZE:=1M}@" /etc/nginx/nginx.conf
-
+sed -i "s@__OPENBLOCKS_FRONTEND_WORKERS__@${OPENBLOCKS_FRONTEND_WORKERS:=1}@" /etc/nginx/nginx.conf
 
 echo "nginx config updated with:"
 echo "    Openblocks api service URL: ${OPENBLOCKS_API_SERVICE_URL}"
 echo "   Openblocks node service URL: ${OPENBLOCKS_NODE_SERVICE_URL}"
 echo " Openblocks Frontend Body Size: ${OPENBLOCKS_FRONTEND_BODY_SIZE}"
+echo "   Openblocks Frontend Workers: ${OPENBLOCKS_FRONTEND_WORKERS}

--- a/deploy/docker/frontend/nginx.conf
+++ b/deploy/docker/frontend/nginx.conf
@@ -1,6 +1,6 @@
 user  openblocks;
 
-worker_processes  1;
+worker_processes  __OPENBLOCKS_FRONTEND_WORKERS__;
 
 events {
     worker_connections  1024;

--- a/deploy/docker/frontend/nginx.conf
+++ b/deploy/docker/frontend/nginx.conf
@@ -28,6 +28,7 @@ http {
 
     keepalive_timeout  65;
     sendfile        on;
+    client_max_body_size __OPENBLOCKS_FRONTEND_BODY_SIZE__;
     #tcp_nopush     on;
 
     server {


### PR DESCRIPTION
The frontend nginx configuration does not provide a sufficient body size for file uploads.

This error is displayed in the container logs when trying to upload anything larger than 1M:

`2023/03/30 19:15:49 [error] 23#23: *50 client intended to send too large body: 7089983 bytes ...`

This change adds an additional environment variable to allow for the body size to be adjusted.